### PR TITLE
Support import of ListenBrainz recommendations playlists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,4 +61,5 @@ Credits
 
 - Fork of `Mopidy-Scrobbler <https://github.com/mopidy/mopidy-scrobbler>`__ by `Stein Magnus Jodal <https://github.com/jodal>`__
 - Current maintainer: `suaviloquence <https://github.com/suaviloquence>`__
+- Playlist support by `Matthias Meulien <https://github.com/orontee>`__
 - `Contributors <https://github.com/suaviloquence/mopidy-listenbrainz/graphs/contributors>`_

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ The following configuration values are available:
 - ``listenbrainz/token``: Your `Listenbrainz user token <https://listenbrainz.org/profile/>`_
 - ``listenbrainz/url``: The URL of the API of the Listenbrainz instance to record listens to (default: api.listenbrainz.org)
 - ``listenbrainz/import_playlists``: Whether to import Listenbrainz playlists (default: ``false``)
+- ``listenbrainz/periodic_playlists_update``: Enable periodic import of Listenbrainz playlists (default: ``true``)
 
 Project resources
 =================

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,6 @@ The following configuration values are available:
 - ``listenbrainz/token``: Your `Listenbrainz user token <https://listenbrainz.org/profile/>`_
 - ``listenbrainz/url``: The URL of the API of the Listenbrainz instance to record listens to (default: api.listenbrainz.org)
 - ``listenbrainz/import_playlists``: Whether to import Listenbrainz playlists (default: ``false``)
-- ``listenbrainz/periodic_playlists_update``: Enable periodic import of Listenbrainz playlists (default: ``true``)
 
 Project resources
 =================

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ The following configuration values are available:
 - ``listenbrainz/token``: Your `Listenbrainz user token <https://listenbrainz.org/profile/>`_
 - ``listenbrainz/url``: The URL of the API of the Listenbrainz instance to record listens to (default: api.listenbrainz.org)
 - ``listenbrainz/import_playlists``: Whether to import Listenbrainz playlists (default: ``false``)
-- ``listenbrainz/search_schemes``: If non empty, the search for tracks in Mopidy's library is limited to results with the given schemes. Leave empty (the default) to search among all backends, but note that it may affect performance; It's recommended to customize the value according to your favorite backends (``file:`` for Mopidy-File, ``local:`` for Mopidy-Local, etc.).
+- ``listenbrainz/search_schemes``: If non empty, the search for tracks in Mopidy's library is limited to results with the given schemes. The default value is ``"local:"`` to search tracks in Mopidy-Local library. It's recommended to customize the value according to your favorite backend but beware that not all backends support the required track search by ``musicbrainz_trackid`` (Mopidy-File, Mopidy-InternetArchive, Mopidy-Podcast, Mopidy-Somafm, Mopidy-Stream don't support such searches).
 
 Project resources
 =================

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ The following configuration values are available:
   Defaults to enabled.
 - ``listenbrainz/token``: Your `Listenbrainz user token <https://listenbrainz.org/profile/>`_
 - ``listenbrainz/url``: The URL of the API of the Listenbrainz instance to record listens to (default: api.listenbrainz.org)
-
+- ``listenbrainz/import_playlists``: Whether to import Listenbrainz playlists (default: ``false``)
 
 Project resources
 =================

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ The following configuration values are available:
 - ``listenbrainz/token``: Your `Listenbrainz user token <https://listenbrainz.org/profile/>`_
 - ``listenbrainz/url``: The URL of the API of the Listenbrainz instance to record listens to (default: api.listenbrainz.org)
 - ``listenbrainz/import_playlists``: Whether to import Listenbrainz playlists (default: ``false``)
+- ``listenbrainz/search_schemes``: If non empty, the search for tracks in Mopidy's library is limited to results with the given schemes. Leave empty (the default) to search among all backends, but note that it may affect performance; It's recommended to customize the value according to your favorite backends (``file:`` for Mopidy-File, ``local:`` for Mopidy-Local, etc.).
 
 Project resources
 =================

--- a/mopidy_listenbrainz/__init__.py
+++ b/mopidy_listenbrainz/__init__.py
@@ -20,6 +20,7 @@ class Extension(ext.Extension):
         schema["token"] = config.Secret()
         schema["url"] = config.String()
         schema["import_playlists"] = config.Boolean()
+        schema["search_schemes"] = config.List(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_listenbrainz/__init__.py
+++ b/mopidy_listenbrainz/__init__.py
@@ -19,9 +19,14 @@ class Extension(ext.Extension):
         schema = super().get_config_schema()
         schema["token"] = config.Secret()
         schema["url"] = config.String()
+        schema["import_playlists"] = config.Boolean()
         return schema
 
     def setup(self, registry):
         from .frontend import ListenbrainzFrontend
 
         registry.add("frontend", ListenbrainzFrontend)
+
+        from .backend import ListenbrainzBackend
+
+        registry.add("backend", ListenbrainzBackend)

--- a/mopidy_listenbrainz/backend.py
+++ b/mopidy_listenbrainz/backend.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar, NewType
 import pykka
 
 from mopidy import backend
+
 try:
     from mopidy.types import UriScheme
 except ModuleNotFoundError:

--- a/mopidy_listenbrainz/backend.py
+++ b/mopidy_listenbrainz/backend.py
@@ -11,7 +11,7 @@ try:
 except ModuleNotFoundError:
     UriScheme = NewType("UriScheme", str)
 
-from . import playlists
+from .playlists import ListenbrainzPlaylistsProvider
 
 if TYPE_CHECKING:
     from mopidy.audio import AudioProxy
@@ -27,4 +27,4 @@ class ListenbrainzBackend(pykka.ThreadingActor, backend.Backend):
         audio: AudioProxy,  # noqa: ARG002
     ) -> None:
         super().__init__()
-        self.playlists = playlists.ListenbrainzPlaylistsProvider(self)
+        self.playlists = ListenbrainzPlaylistsProvider(self)

--- a/mopidy_listenbrainz/backend.py
+++ b/mopidy_listenbrainz/backend.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+import pykka
+
+from mopidy import backend
+from mopidy.types import UriScheme
+
+from . import playlists
+
+if TYPE_CHECKING:
+    from mopidy.audio import AudioProxy
+    from mopidy.ext import Config
+
+
+class ListenbrainzBackend(pykka.ThreadingActor, backend.Backend):
+    uri_schemes: ClassVar[list[UriScheme]] = [UriScheme("listenbrainz")]
+
+    def __init__(
+        self,
+        config: Config,  # noqa: ARG002
+        audio: AudioProxy,  # noqa: ARG002
+    ) -> None:
+        super().__init__()
+        self.playlists = playlists.ListenbrainzPlaylistsProvider(self)

--- a/mopidy_listenbrainz/backend.py
+++ b/mopidy_listenbrainz/backend.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, NewType
 
 import pykka
 
 from mopidy import backend
-from mopidy.types import UriScheme
+try:
+    from mopidy.types import UriScheme
+except ModuleNotFoundError:
+    UriScheme = NewType("UriScheme", str)
 
 from . import playlists
 

--- a/mopidy_listenbrainz/ext.conf
+++ b/mopidy_listenbrainz/ext.conf
@@ -3,3 +3,4 @@ enabled = true
 token = 
 url = api.listenbrainz.org
 import_playlists = false
+search_schemes = 

--- a/mopidy_listenbrainz/ext.conf
+++ b/mopidy_listenbrainz/ext.conf
@@ -3,4 +3,4 @@ enabled = true
 token = 
 url = api.listenbrainz.org
 import_playlists = false
-search_schemes = 
+search_schemes = "local:"

--- a/mopidy_listenbrainz/ext.conf
+++ b/mopidy_listenbrainz/ext.conf
@@ -2,3 +2,4 @@
 enabled = true
 token = 
 url = api.listenbrainz.org
+import_playlists = false

--- a/mopidy_listenbrainz/ext.conf
+++ b/mopidy_listenbrainz/ext.conf
@@ -3,3 +3,4 @@ enabled = true
 token = 
 url = api.listenbrainz.org
 import_playlists = false
+periodic_playlists_update = true

--- a/mopidy_listenbrainz/ext.conf
+++ b/mopidy_listenbrainz/ext.conf
@@ -3,4 +3,3 @@ enabled = true
 token = 
 url = api.listenbrainz.org
 import_playlists = false
-periodic_playlists_update = true

--- a/mopidy_listenbrainz/ext.conf
+++ b/mopidy_listenbrainz/ext.conf
@@ -3,4 +3,4 @@ enabled = true
 token = 
 url = api.listenbrainz.org
 import_playlists = false
-search_schemes = "local:"
+search_schemes = local:

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -33,7 +33,7 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
 
         if self.config["listenbrainz"].get("import_playlists", False):
             search_schemes = self.config["listenbrainz"].get(
-                "search_schemes", "local:"
+                "search_schemes", ["local:"]
             )
             if len(search_schemes) > 0:
                 logger.debug(
@@ -130,7 +130,7 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
         self, playlist_data: PlaylistData
     ) -> List[Track]:
         tracks: List[Track] = []
-        search_schemes = self.config["listenbrainz"].get("search_schemes", [])
+        search_schemes = self.config["listenbrainz"].get("search_schemes", ["local:"])
 
         for track_mbid in playlist_data.track_mbids:
             query = self.library.search(

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -33,14 +33,17 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
 
         if self.config["listenbrainz"].get("import_playlists", False):
             search_schemes = self.config["listenbrainz"].get(
-                "search_schemes", []
+                "search_schemes", "local:"
             )
             if len(search_schemes) > 0:
                 logger.debug(
                     f"Will limit track searches to URIs: {search_schemes}"
                 )
             else:
-                logger.debug("Will search tracks among all backends")
+                msg = "Track searches among all backends aren't stable! " \
+                    "Better configure `search_schemes' to match your " \
+                    "favorite backend"
+                logger.warn(msg)
 
             self.import_playlists()
 

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -32,9 +32,13 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
         logger.debug("Listenbrainz token valid!")
 
         if self.config["listenbrainz"].get("import_playlists", False):
-            search_schemes = self.config["listenbrainz"].get("search_schemes", [])
+            search_schemes = self.config["listenbrainz"].get(
+                "search_schemes", []
+            )
             if len(search_schemes) > 0:
-                logger.debug(f"Will limit track searches to URIs: {search_schemes}")
+                logger.debug(
+                    f"Will limit track searches to URIs: {search_schemes}"
+                )
             else:
                 logger.debug("Will search tracks among all backends")
 
@@ -144,12 +148,8 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
     def _schedule_playlists_import(self):
         now = datetime.now()
         days_until_next_monday = 7 - now.weekday()
-        timer_interval = timedelta(
-            days=days_until_next_monday
-        ).total_seconds()
-        logger.debug(
-            f"Playlist update scheduled in {timer_interval} seconds"
-        )
+        timer_interval = timedelta(days=days_until_next_monday).total_seconds()
+        logger.debug(f"Playlist update scheduled in {timer_interval} seconds")
         self.playlists_update_timer = Timer(
             timer_interval, self.import_playlists
         )

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -91,7 +91,7 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
             else:
                 import_count += 1
                 logger.debug(
-                    f"Playlist {playlist.uri!r} imported from {source!r}"
+                    f"Tracks saved for playlist {playlist.uri!r}: {len(playlist.tracks)!r}"
                 )
 
         logger.info(

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -134,19 +134,18 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
         return tracks
 
     def _schedule_playlists_import(self):
-        if self.config["listenbrainz"].get("periodic_playlists_update", True):
-            now = datetime.now()
-            days_until_next_monday = 7 - now.weekday()
-            timer_interval = timedelta(
-                days=days_until_next_monday
-            ).total_seconds()
-            logger.debug(
-                f"Playlist update scheduled in {timer_interval} seconds"
-            )
-            self.playlists_update_timer = Timer(
-                timer_interval, self.import_playlists
-            )
-            self.playlists_update_timer.start()
+        now = datetime.now()
+        days_until_next_monday = 7 - now.weekday()
+        timer_interval = timedelta(
+            days=days_until_next_monday
+        ).total_seconds()
+        logger.debug(
+            f"Playlist update scheduled in {timer_interval} seconds"
+        )
+        self.playlists_update_timer = Timer(
+            timer_interval, self.import_playlists
+        )
+        self.playlists_update_timer.start()
 
     def track_playback_started(self, tl_track):
         track = tl_track.track

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -133,9 +133,6 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
             query = self.library.search(
                 {"musicbrainz_trackid": [track_mbid]}, uris=search_schemes
             )
-            # search only in local database since other backends can
-            # be quite long to answer, should we offer choice through
-            # config?
             results = query.get()
 
             found_tracks = [t for r in results for t in r.tracks]

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -3,6 +3,7 @@ import time
 
 import pykka
 from mopidy.core import CoreListener
+from mopidy.models import Playlist
 
 from .listenbrainz import Listenbrainz
 
@@ -15,13 +16,85 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
     def __init__(self, config, core):
         super().__init__()
         self.config = config
+        self.library = core.library
+        self.playlists = core.playlists
 
     def on_start(self):
         self.lb = Listenbrainz(
             self.config["listenbrainz"]["token"],
             self.config["listenbrainz"]["url"],
+            self.config["proxy"],
         )
         logger.debug("Listenbrainz token valid!")
+
+        if self.config["listenbrainz"].get("import_playlists", False):
+            self.import_playlists()
+
+    def import_playlists(self) -> None:
+        logger.info("Import of ListenBrainz playlists")
+
+        import_count = 0
+        playlist_datas = self.lb.list_playlists_created_for_user()
+        logger.debug(f"Found {len(playlist_datas)} playlists to import")
+
+        for playlist_data in playlist_datas:
+            source = playlist_data.get("playlist_id", "")
+            tracks = []
+            for track_mbid in playlist_data.get("track_mbids", []):
+                query = self.library.search(
+                    {"musicbrainz_trackid": [track_mbid]}, uris=["local:"]
+                )
+                # search only in local database since other backends
+                # can be quite long to answer
+                results = query.get()
+
+                found_tracks = [t for r in results for t in r.tracks]
+                if len(found_tracks) == 0:
+                    logger.debug(
+                        f"Library has no track with MBID {track_mbid!r}"
+                    )
+                    continue
+                elif len(found_tracks) > 1:
+                    logger.debug(
+                        f"Library has multiple tracks with MBID {track_mbid!r}"
+                    )
+
+                tracks.append(found_tracks[0])
+
+            if len(tracks) == 0:
+                logger.warning(
+                    f"Skipping import of playlist with no tracks for {source!r}"
+                )
+                continue
+
+            playlist_name = playlist_data.get("name", "")
+            query = self.playlists.create(
+                playlist_name, uri_scheme="listenbrainz"
+            )
+            playlist = query.get()
+            if playlist is None:
+                logger.warning(f"Failed to create playlist for {source!r}")
+                continue
+
+            complete_playlist = Playlist(
+                uri=playlist.uri,
+                name=playlist_name,
+                tracks=tracks,
+                last_modified=playlist_data.get("last_modified"),
+            )
+            query = self.playlists.save(complete_playlist)
+            playlist = query.get()
+            if playlist is None:
+                logger.warning(f"Failed to save playlist for {source!r}")
+            else:
+                import_count += 1
+                logger.debug(
+                    f"Playlist {playlist.uri!r} imported from {source!r}"
+                )
+
+        logger.info(
+            f"Successfull import of ListenBrainz playlists: {import_count}"
+        )
 
     def track_playback_started(self, tl_track):
         track = tl_track.track

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -32,6 +32,12 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
         logger.debug("Listenbrainz token valid!")
 
         if self.config["listenbrainz"].get("import_playlists", False):
+            search_schemes = self.config["listenbrainz"].get("search_schemes", [])
+            if len(search_schemes) > 0:
+                logger.debug(f"Will limit track searches to URIs: {search_schemes}")
+            else:
+                logger.debug("Will search tracks among all backends")
+
             self.import_playlists()
 
     def on_stop(self):
@@ -117,9 +123,11 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
         self, playlist_data: PlaylistData
     ) -> List[Track]:
         tracks: List[Track] = []
+        search_schemes = self.config["listenbrainz"].get("search_schemes", [])
+
         for track_mbid in playlist_data.track_mbids:
             query = self.library.search(
-                {"musicbrainz_trackid": [track_mbid]}, uris=["local:"]
+                {"musicbrainz_trackid": [track_mbid]}, uris=search_schemes
             )
             # search only in local database since other backends can
             # be quite long to answer, should we offer choice through

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -39,7 +39,7 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
             self.playlists_update_timer.cancel()
 
     def import_playlists(self) -> None:
-        logger.info("Import of ListenBrainz playlists")
+        logger.info("Importing ListenBrainz playlists")
 
         import_count = 0
         playlist_datas = self.lb.list_playlists_created_for_user()
@@ -109,7 +109,7 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
             self.playlists.delete(playlist.uri)
 
         logger.info(
-            f"Successfull import of ListenBrainz playlists: {import_count}"
+            f"Successfully imported ListenBrainz playlists: {import_count}"
         )
         self._schedule_playlists_import()
 

--- a/mopidy_listenbrainz/frontend.py
+++ b/mopidy_listenbrainz/frontend.py
@@ -76,6 +76,8 @@ class ListenbrainzFrontend(pykka.ThreadingActor, CoreListener):
                 logger.warning(f"Failed to create playlist for {source!r}")
                 continue
 
+            logger.debug(f"Playlist {playlist.uri!r} created from {source!r}")
+
             complete_playlist = Playlist(
                 uri=playlist.uri,
                 name=playlist_name,

--- a/mopidy_listenbrainz/listenbrainz.py
+++ b/mopidy_listenbrainz/listenbrainz.py
@@ -143,6 +143,10 @@ class Listenbrainz(object):
         )
 
     def list_playlists_created_for_user(self) -> List[PlaylistData]:
+        """List all playlist data from the "created for" endpoint.
+
+        The "created for" endpoint list recommendation playlists; It
+        is defined in ``LIST_PLAYLIST_CREATED_FOR_ENDPOINT``."""
         if self.user_name is None:
             logger.warning("No playlist created for unknown user!")
             return []

--- a/mopidy_listenbrainz/listenbrainz.py
+++ b/mopidy_listenbrainz/listenbrainz.py
@@ -1,27 +1,82 @@
+import datetime
+import logging
 import time
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import pkg_resources
+from mopidy import httpclient
 
 import requests
 
 from . import __version__
 
+logger = logging.getLogger(__name__)
+
+# Listenbrainz API
+LIST_PLAYLIST_CREATED_FOR_ENDPOINT = "/1/user/{user}/playlists/createdfor"
+PLAYLIST_ENDPOINT = "/1/playlist/{playlist_id}"
 SUBMIT_LISTEN_ENDPOINT = "/1/submit-listens"
 VALIDATE_TOKEN_ENDPOINT = "/1/validate-token"
+
+# Musicbrainz resources
+MUSICBRAINZ_PLAYLIST_EXTENSION_URL = "https://musicbrainz.org/doc/jspf#playlist"
+
+
+def playlist_identifier_to_id(playlist_identifier: str) -> Optional[str]:
+    playlist_path = urlparse(playlist_identifier).path
+    path_prefix = "/playlist/"
+    return (
+        playlist_path[len(path_prefix) :]
+        if playlist_path.startswith(path_prefix)
+        else None
+    )
+
+
+def track_identifier_to_mbid(track_identifier: str) -> Optional[str]:
+    track_path = urlparse(track_identifier).path
+    path_prefix = "/recording/"
+    return (
+        track_path[len(path_prefix) :]
+        if track_path.startswith(path_prefix)
+        else None
+    )
+
+
+def get_requests_session(proxy_config, user_agent):
+    proxy = httpclient.format_proxy(proxy_config)
+    full_user_agent = httpclient.format_user_agent(user_agent)
+
+    session = requests.Session()
+    session.proxies.update({"http": proxy, "https": proxy})
+    session.headers.update({"user-agent": full_user_agent})
+
+    return session
 
 
 class Listenbrainz(object):
     token: str
     url: str
 
-    def __init__(self, token: str, url: str) -> None:
+    user_name: Optional[str]
+
+    def __init__(self, token: str, url: str, proxy_config: Any) -> None:
         self.token = token
         self.url = url
+
+        self.user_name = None  # initialized during token validation
+
+        dist = pkg_resources.get_distribution("Mopidy-Listenbrainz")
+        self.session = get_requests_session(
+            proxy_config=proxy_config,
+            user_agent=f"{dist.project_name}/{dist.version}",
+        )
 
         if not self.validate_token():
             raise RuntimeError(f"Token {token} is not valid")
 
     def validate_token(self) -> bool:
-        response = requests.get(
+        response = self.session.get(
             url=f"https://{self.url}{VALIDATE_TOKEN_ENDPOINT}",
             headers={
                 "Authorization": f"Token {self.token}",
@@ -31,7 +86,9 @@ class Listenbrainz(object):
         if response.status_code != 200:
             return False
 
-        return response.json()["valid"]
+        parsed_response = response.json()
+        self.user_name = parsed_response.get("user_name")
+        return parsed_response.get("valid")
 
     def submit_listen(
         self,
@@ -64,7 +121,7 @@ class Listenbrainz(object):
 
         payload = [listen]
 
-        response = requests.post(
+        response = self.session.post(
             # hardcode https?
             url=f"https://{self.url}{SUBMIT_LISTEN_ENDPOINT}",
             json={
@@ -75,3 +132,111 @@ class Listenbrainz(object):
                 "Authorization": f"Token {self.token}",
             },
         )
+
+    def list_playlists_created_for_user(self) -> List[Dict[str, Any]]:
+        if self.user_name is None:
+            logger.warning("No playlist created for unknown user!")
+            return []
+
+        path = LIST_PLAYLIST_CREATED_FOR_ENDPOINT.format(user=self.user_name)
+        response = self.session.get(
+            url=f"https://{self.url}{path}",
+            headers={
+                "Authorization": f"Token {self.token}",
+            },
+        )
+        parsed_response = response.json()
+        playlists: List[Dict[str, Any]] = []
+        found_playlists: List[str] = []
+        for dto in parsed_response.get("playlists", []):
+            playlist_dto = dto.get("playlist", {})
+            playlist_identifier = playlist_dto.get("identifier")
+
+            if playlist_identifier is None:
+                logger.debug(f"Skipping playlist without identifier")
+                continue
+
+            if playlist_identifier in found_playlists:
+                logger.warning(f"Duplicated playlist {playlist_identifier!r}")
+                continue
+
+            found_playlists.append(playlist_identifier)
+
+            playlist_data = self._collect_playlist_data(playlist_identifier)
+            if playlist_data is None:
+                logger.warning(
+                    f"Failed to build playlist {playlist_identifier!r}"
+                )
+                continue
+
+            playlists.append(playlist_data)
+
+        return playlists
+
+    def _collect_playlist_data(
+        self, playlist_identifier: str
+    ) -> Optional[Dict[str, Any]]:
+        """Collect playlist data from a ListenBrainz playlist identifier.
+
+        The ListenBrainz playlist identifier is a URL whose last path
+        segment identifies the playlist. A playlist DTO is fetched
+        from that identifier using ListenBrainz API.
+
+        If the ListenBrainz playlist identifier doesn't match our
+        expectations (see ``playlist_identifier_to_id()``), or the DTO
+        hasn't the expected fields (``name``, ``date``), None is
+        returned.
+
+        MusicBrainz track identifiers are extracted from the tracks
+        identifiers found in the DTO ``tracks`` field.
+
+        """
+        playlist_id = playlist_identifier_to_id(playlist_identifier)
+        if playlist_id is None:
+            logger.warning(
+                f"Failed to extract playlist id from {playlist_identifier}"
+            )
+            return None
+
+        path = PLAYLIST_ENDPOINT.format(playlist_id=playlist_id)
+        response = self.session.get(
+            url=f"https://{self.url}{path}",
+            headers={
+                "Authorization": f"Token {self.token}",
+            },
+        )
+        parsed_response = response.json()
+        dto = parsed_response.get("playlist", {})
+        name = dto.get("title")
+        if name is None:
+            logger.debug(f"Unable to read a name from playlist {playlist_id!r}")
+            return None
+        try:
+            creation_date = datetime.datetime.fromisoformat(dto.get("date"))
+        except (ValueError, TypeError):
+            logger.warning(f"Failed to parse date for playlist {playlist_id!r}")
+            return None
+        track_mbids = []
+        for track_dto in dto.get("track", []):  # not tracks!
+            track_identifier = track_dto.get("identifier", "")
+            track_mbid = track_identifier_to_mbid(track_identifier)
+            if track_mbid is None:
+                logger.debug(
+                    f"Failed to identify MBID from {track_identifier!r}"
+                )
+                continue
+
+            track_mbids.append(track_mbid)
+
+        if len(track_mbids) == 0:
+            logger.debug(
+                f"No MBID found for tracks of playlist {playlist_id!r}"
+            )
+            return None
+
+        return {
+            "playlist_id": playlist_id,
+            "name": name,
+            "track_mbids": track_mbids,
+            "last_modified": int(creation_date.timestamp()),
+        }

--- a/mopidy_listenbrainz/playlists.py
+++ b/mopidy_listenbrainz/playlists.py
@@ -1,0 +1,84 @@
+import datetime
+import logging
+from typing import cast, List
+from uuid import uuid4
+
+from mopidy.backend import Backend, PlaylistsProvider
+from mopidy.models import Playlist, Ref
+from mopidy.types import Uri, UriScheme
+
+
+logger = logging.getLogger(__name__)
+
+
+class ListenbrainzPlaylistsProvider(PlaylistsProvider):
+    """Provider for ListenBrainz playlists.
+
+    Note that this provider doesn't serialize the playlists. They're
+    expected to be created by the frontend on each extension setup.
+
+    This provider handles URIs with scheme ``listenbrainz:playlist``.
+
+    """
+
+    uri_prefix: UriScheme
+    playlists: List[Playlist]
+
+    def __init__(self, backend: Backend) -> None:
+        super().__init__(backend)
+
+        assert len(backend.uri_schemes) == 1
+        self.uri_prefix = cast(UriScheme, backend.uri_schemes[0] + ":playlist")
+        self.playlists = []
+
+    def as_list(self) -> List[Ref]:
+        return [Ref.playlist(uri=p.uri, name=p.name) for p in self.playlists]
+
+    def create(self, name: str) -> Playlist | None:
+        uri = f"{self.uri_prefix}:{uuid4()}"
+        playlist = Playlist(uri=uri)
+        self.playlists.append(playlist)
+        return playlist
+
+    def delete(self, uri: Uri) -> bool:
+        return False
+
+    def get_items(self, uri: Uri) -> List[Ref] | None:
+        if not uri.startswith(self.uri_prefix):
+            return None
+
+        found = [p for p in self.playlists if p.uri == uri]
+        if len(found) == 0:
+            return None
+
+        return [Ref.playlist(uri=p.uri, name=p.name) for p in found]
+
+    def lookup(self, uri: Uri) -> Playlist | None:
+        if not uri.startswith(self.uri_prefix):
+            return None
+
+        found = [p for p in self.playlists if p.uri == uri]
+        if len(found) == 0:
+            return None
+
+        return found[0]
+
+    def refresh(self) -> None:
+        pass
+
+    def save(self, playlist: Playlist) -> Playlist | None:
+        uri = playlist.uri
+
+        if not uri.startswith(self.uri_prefix):
+            return None
+
+        found = [p for p in self.playlists if p.uri == uri]
+        if len(found) == 0:
+            return None
+
+        if len(found[0].tracks) > 0:
+            return None  #  Playlists are expected to be saved
+            #  once, by the frontend
+
+        found[0] = playlist
+        return found[0]

--- a/mopidy_listenbrainz/playlists.py
+++ b/mopidy_listenbrainz/playlists.py
@@ -84,5 +84,6 @@ class ListenbrainzPlaylistsProvider(PlaylistsProvider):
             return None  #  Playlists are expected to be saved
             #  once, by the frontend
 
-        found[0] = playlist
-        return found[0]
+        pos = self.playlists.index(found[0])
+        self.playlists[pos] = playlist
+        return self.playlists[pos]

--- a/mopidy_listenbrainz/playlists.py
+++ b/mopidy_listenbrainz/playlists.py
@@ -93,6 +93,14 @@ class ListenbrainzPlaylistsProvider(PlaylistsProvider):
         if len(found) == 0:
             return None
 
+        if uri.startswith(self.uri_prefix + ":recommendation"):
+            if not (len(playlist.tracks) > len(found[0].tracks)):
+                # return unchanged playlist for recommendations whose
+                # track list isn't increasing, really save iff first
+                # save after creation or new tracks being available in
+                # Mopidy's database
+                return found[0]
+
         pos = self.playlists.index(found[0])
         self.playlists[pos] = playlist
         return self.playlists[pos]

--- a/mopidy_listenbrainz/playlists.py
+++ b/mopidy_listenbrainz/playlists.py
@@ -40,7 +40,7 @@ class ListenbrainzPlaylistsProvider(PlaylistsProvider):
 
     def create(self, name: str) -> Playlist | None:
         uri = f"{self.uri_prefix}:{uuid4()}"
-        playlist = Playlist(uri=uri)
+        playlist = Playlist(uri=uri, name=name)
         self.playlists.append(playlist)
         return playlist
 

--- a/mopidy_listenbrainz/playlists.py
+++ b/mopidy_listenbrainz/playlists.py
@@ -1,11 +1,15 @@
 import datetime
 import logging
-from typing import cast, List
+from typing import cast, List, NewType
 from uuid import uuid4
 
 from mopidy.backend import Backend, PlaylistsProvider
 from mopidy.models import Playlist, Ref
-from mopidy.types import Uri, UriScheme
+try:
+    from mopidy.types import Uri, UriScheme
+except ModuleNotFoundError:
+    Uri = NewType("Uri", str)
+    UriScheme = NewType("UriScheme", str)
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Proposal

The proposed branch adds support for playlists returned by the [playlists created for](https://listenbrainz.readthedocs.io/en/latest/users/api/playlist.html#get--1-user-(playlist_user_name)-playlists-createdfor) endpoint (recommendations playlists) from ListenBrainz API.

AFAICT the returned playlists are made of suggestions taken from previously listened tracks. 

## Implementation

The playlist descriptions are fetched by the existing Mopidy frontend during setup.  Mopidy-Local database is then searched for matching tracks and Mopidy playlists are created using a trivial Mopidy backend dedicated to those playlists management.

The playlist import must be enabled using a new configuration key `import_playlists` (default to `false`).

Playlists are periodically updated (each week, on monday).

## Possible improvements

- Import all user playlists, not only recommendations
- Make user playlists editable and synchronized with Listenbrainz
- Import playlists from other users, but doesn't make much sense if one doesn't have a huge local library... What do you think?

## Test

`python -m pip install --upgrade --break-system-packages git+https://github.com/orontee/mopidy-listenbrainz.git@feature/playlists`

Tried with both [Argos](https://github.com/orontee/argos) and [Iris](https://github.com/jaedb/Iris).

![image](https://github.com/suaviloquence/mopidy-listenbrainz/assets/2065954/05276660-3fc1-4148-8a44-2011675fc786)

![image](https://github.com/suaviloquence/mopidy-listenbrainz/assets/2065954/e10488a7-e9a0-4e80-9fed-2de7dc1871a9)
