### PR TITLE
Revert "use trusted publishing for pypi (#12)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,6 @@ jobs:
       run: python3 -m build
     - uses: pypa/gh-action-pypi-publish@v1.8.14
       with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
         verify-metadata: true


### PR DESCRIPTION
This reverts commit 6a52ccce3fd0da5cdf127fea7c9de28528508954.
