### PR TITLE
Support 4.0.0

### DIFF
--- a/mopidy_listenbrainz/__init__.py
+++ b/mopidy_listenbrainz/__init__.py
@@ -1,12 +1,14 @@
 import pathlib
+from importlib.metadata import distribution
 
-import pkg_resources
 import email.parser
 from mopidy import config, ext
 
 __dist_name__ = "Mopidy-Listenbrainz"
-_dist = pkg_resources.get_distribution(__dist_name__)
-_pkg_info = _dist.get_metadata("METADATA")
+
+
+_dist = distribution(__dist_name__)
+_pkg_info = _dist.read_text("METADATA")
 _metadata = email.parser.Parser().parsestr(_pkg_info)
 
 __version__ = _dist.version

--- a/mopidy_listenbrainz/listenbrainz.py
+++ b/mopidy_listenbrainz/listenbrainz.py
@@ -59,7 +59,7 @@ def get_http_client(proxy_config, user_agent):
         proxy=httpclient.format_proxy(proxy_config),
         headers={
             "user-agent": full_user_agent,
-        }
+        },
     )
     return client
 

--- a/mopidy_listenbrainz/listenbrainz.py
+++ b/mopidy_listenbrainz/listenbrainz.py
@@ -2,10 +2,11 @@ import datetime
 import logging
 import time
 from dataclasses import dataclass
+from importlib.metadata import distribution
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-import pkg_resources
+
 from mopidy import httpclient
 
 import requests
@@ -94,10 +95,10 @@ class Listenbrainz(object):
 
         self.user_name = None  # initialized during token validation
 
-        dist = pkg_resources.get_distribution("Mopidy-Listenbrainz")
+        dist = distribution("Mopidy-Listenbrainz")
         self.session = get_requests_session(
             proxy_config=proxy_config,
-            user_agent=f"{dist.project_name}/{dist.version}",
+            user_agent=f"{dist.name}/{dist.version}",
         )
 
         if not self.validate_token():

--- a/mopidy_listenbrainz/listenbrainz.py
+++ b/mopidy_listenbrainz/listenbrainz.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from mopidy import httpclient
 
-import requests
+import httpx
 
 from . import __version__
 
@@ -53,22 +53,22 @@ def track_identifier_to_mbid(track_identifier: str) -> Optional[str]:
     )
 
 
-def get_requests_session(proxy_config, user_agent):
-    proxy = httpclient.format_proxy(proxy_config)
+def get_http_client(proxy_config, user_agent):
     full_user_agent = httpclient.format_user_agent(user_agent)
-
-    session = requests.Session()
-    session.proxies.update({"http": proxy, "https": proxy})
-    session.headers.update({"user-agent": full_user_agent})
-
-    return session
+    client = httpx.Client(
+        proxy=httpclient.format_proxy(proxy_config),
+        headers={
+            "user-agent": full_user_agent,
+        }
+    )
+    return client
 
 
 class _RequestError(Exception):
     pass
 
 
-def check_response_status(response: requests.Response) -> None:
+def check_response_status(response: httpx.Response) -> None:
     if response.status_code == 200:
         return
     elif response.status_code == 400:
@@ -96,7 +96,7 @@ class Listenbrainz(object):
         self.user_name = None  # initialized during token validation
 
         dist = distribution("Mopidy-Listenbrainz")
-        self.session = get_requests_session(
+        self.client = get_http_client(
             proxy_config=proxy_config,
             user_agent=f"{dist.name}/{dist.version}",
         )
@@ -105,7 +105,7 @@ class Listenbrainz(object):
             raise RuntimeError(f"Token {token} is not valid")
 
     def validate_token(self) -> bool:
-        response = self.session.get(
+        response = self.client.get(
             url=f"https://{self.url}{VALIDATE_TOKEN_ENDPOINT}",
             headers={
                 "Authorization": f"Token {self.token}",
@@ -156,7 +156,7 @@ class Listenbrainz(object):
 
         payload = [listen]
 
-        response = self.session.post(
+        response = self.client.post(
             # hardcode https?
             url=f"https://{self.url}{SUBMIT_LISTEN_ENDPOINT}",
             json={
@@ -182,7 +182,7 @@ class Listenbrainz(object):
             return []
 
         path = LIST_PLAYLIST_CREATED_FOR_ENDPOINT.format(user=self.user_name)
-        response = self.session.get(
+        response = self.client.get(
             url=f"https://{self.url}{path}",
             headers={
                 "Authorization": f"Token {self.token}",
@@ -244,7 +244,7 @@ class Listenbrainz(object):
             return None
 
         path = PLAYLIST_ENDPOINT.format(playlist_id=playlist_id)
-        response = self.session.get(
+        response = self.client.get(
             url=f"https://{self.url}{path}",
             headers={
                 "Authorization": f"Token {self.token}",

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ classifiers =
     Intended Audience :: End Users/Desktop
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -27,10 +25,10 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >= 3.7
+python_requires = >= 3.8
 install_requires =
-    Mopidy >= 3.0.0
-    Pykka >= 2.0.1
+    Mopidy >= 4.0.0
+    Pykka >= 4.4.2
     setuptools
     musicbrainzngs >= 0.7.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,7 @@ classifiers =
     Intended Audience :: End Users/Desktop
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Multimedia :: Sound/Audio :: Players
 
 
@@ -25,11 +21,10 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >= 3.8
+python_requires = >= 3.13
 install_requires =
     Mopidy >= 4.0.0
     Pykka >= 4.4.2
-    setuptools
     musicbrainzngs >= 0.7.1
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,10 @@ lint =
     flake8-black
     flake8-bugbear
     flake8-import-order
+test =
+    pytest
+    pytest-cov
+
 
 [options.packages.find]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311, py312, check-manifest
+envlist = py313, check-manifest
 
 [testenv]
 sitepackages = true


### PR DESCRIPTION
Three things:
* Replaces `pkg_resources` with `importlib` from the standard library 
* Replaces `requests` by `httpx` which is  what Mopidy >= 4 uses
* Adapt dependencies (`importlib` introduced in Python 3.8, users encouraged to migrate from `pkg_resources` in Python 3.8)